### PR TITLE
KSP2-2560 Use barrier queue when setting delegate

### DIFF
--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -64,7 +64,6 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         public init() {}
         
         public func buildConnection(forURL url: URL, withHeaders headers: [String: String]) throws -> CocoaMQTTWebSocketConnection {
-            
             let config = URLSessionConfiguration.default
             config.httpAdditionalHeaders = headers
             return CocoaMQTTWebSocket.FoundationConnection(url: url, config: config)
@@ -72,8 +71,8 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
     }
     
     public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
+        self.delegate = theDelegate
         internalQueue.async {
-            self.delegate = theDelegate
             self.delegateQueue = delegateQueue
         }
     }
@@ -142,7 +141,22 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         }
     }
     
-    internal var delegate: CocoaMQTTSocketDelegate?
+    private var _delegate: CocoaMQTTSocketDelegate?
+    internal var isolationQueue = DispatchQueue(label: "IsolationQueue", attributes: .concurrent)
+    internal var delegate: CocoaMQTTSocketDelegate? {
+        set {
+            isolationQueue.async(flags: .barrier) {
+                self._delegate = newValue
+            }
+        }
+        
+        get {
+            isolationQueue.sync {
+                _delegate
+            }
+        }
+    }
+
     internal var delegateQueue: DispatchQueue?
     internal var internalQueue = DispatchQueue(label: "CocoaMQTTWebSocket")
 


### PR DESCRIPTION
ThreadSanitizer reported a data race issue when accessing the delegate and delegateQueue properties. The existing implementation assigns these properties asynchronously using a serial queue:

```
internal var internalQueue = DispatchQueue(label: "CocoaMQTTWebSocket")

public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
    internalQueue.async {
        self.delegate = theDelegate
        self.delegateQueue = delegateQueue
    }
}
```
Although a serial queue is used, the asynchronous call (async) does not guarantee timing consistency, which could lead to concurrent reads and writes if other parts of the code access delegate outside this queue.

## Solution
We changed the queue to a concurrent DispatchQueue and updated the setter method to use a .barrier flag. This ensures:
Multiple concurrent reads are allowed.
Writes are serialized with a barrier and will not happen concurrently with reads or other writes.

This approach ensures thread-safe reads and writes without blocking non-mutating operations.