### PR TITLE
KSP2-2560 Access loger minLevel in a concurrent queue

### DIFF
--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -237,12 +237,17 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     
 
     /// Console log level
+    private let loggerQueue = DispatchQueue(label: "CocoaMQTTLogger.queue", attributes: .concurrent)
     public var logLevel: CocoaMQTTLoggerLevel {
         get {
-            return CocoaMQTTLogger.logger.minLevel
+            loggerQueue.sync {
+                CocoaMQTTLogger.logger.minLevel
+            }
         }
         set {
-            CocoaMQTTLogger.logger.minLevel = newValue
+            loggerQueue.async(flags: .barrier) {
+                CocoaMQTTLogger.logger.minLevel = newValue
+            }
         }
     }
 


### PR DESCRIPTION
## Issue
```
WARNING: ThreadSanitizer: data race (pid=82961)
  Write of size 1 at 0x00010bd0eb18 by thread T342:
    #0 CocoaMQTT.CocoaMQTTLogger.minLevel.setter : CocoaMQTT.CocoaMQTTLoggerLevel <null> (Sports.debug.dylib:arm64+0x678b2c8)
    #1 CocoaMQTT.CocoaMQTT5.logLevel.setter : CocoaMQTT.CocoaMQTTLoggerLevel <null> (Sports.debug.dylib:arm64+0x675cde8)
    #2 KSPProvider.CocoaMQTTClient.(makeMQTTClient in _328B7F2CDB09E6727F76035FE7F7EE01)(for: KSPFoundation.MQTTClientConfiguration) -> CocoaMQTT.CocoaMQTT5 <null> (Sports.debug.dylib:arm64+0x666553c)
    #3 KSPProvider.CocoaMQTTClient.connect() -> () <null> (Sports.debug.dylib:arm64+0x666442c)
    #4 protocol witness for KSPFoundation.MQTTClientProtocol.connect() -> () in conformance KSPProvider.CocoaMQTTClient : KSPFoundation.MQTTClientProtocol in KSPProvider <null> (Sports.debug.dylib:arm64+0x66667c0)
    #5 closure #1 () -> () in closure #1 () async -> () in KSPProvider.MQTTManager.connect() -> () <null> (Sports.debug.dylib:arm64+0x6671b20)
    #6 partial apply forwarder for closure #1 () -> () in closure #1 () async -> () in KSPProvider.MQTTManager.connect() -> () <null> (Sports.debug.dylib:arm64+0x6674d78)
    #7 KSPProvider.MQTTConnection.connect(connectAction: () -> ()) -> () <null> (Sports.debug.dylib:arm64+0x666bd6c)
    #8 (2) suspend resume partial function for closure #1 () async -> () in KSPProvider.MQTTManager.connect() -> () <null> (Sports.debug.dylib:arm64+0x6671948)
    #9 swift::runJobInEstablishedExecutorContext(swift::Job*) <null> (libswift_Concurrency.dylib:arm64+0x42c2c)

  Previous read of size 1 at 0x00010bd0eb18 by thread T336:
    #0 CocoaMQTT.CocoaMQTTLogger.minLevel.getter : CocoaMQTT.CocoaMQTTLoggerLevel <null> (Sports.debug.dylib:arm64+0x678b204)
    #1 CocoaMQTT.CocoaMQTTLogger.log(level: CocoaMQTT.CocoaMQTTLoggerLevel, message: Swift.String) -> () <null> (Sports.debug.dylib:arm64+0x678b504)
    #2 CocoaMQTT.CocoaMQTTLogger.debug(Swift.String) -> () <null> (Sports.debug.dylib:arm64+0x678b9f0)
    #3 CocoaMQTT.printDebug(Swift.String) -> () <null> (Sports.debug.dylib:arm64+0x678a18c)
    #4 CocoaMQTT.CocoaMQTT5.(send in _AF8BB6527D0EA3A0219B32C04023BCD8)(_: CocoaMQTT.Frame, tag: Swift.Int) -> () <null> (Sports.debug.dylib:arm64+0x6764e48)
    #5 CocoaMQTT.CocoaMQTT5.subscribe(Swift.Array<CocoaMQTT.MqttSubscription>) -> () <null> (Sports.debug.dylib:arm64+0x6768cac)
    #6 CocoaMQTT.CocoaMQTT5.subscribe(_: Swift.String, qos: CocoaMQTT.CocoaMQTTQoS) -> () <null> (Sports.debug.dylib:arm64+0x6768aec)
    #7 KSPProvider.CocoaMQTTClient.subscribe<A where A: KSPFoundation.MQTTTopicProtocol>(topic: A) -> () <null> (Sports.debug.dylib:arm64+0x6665fc0)
    #8 protocol witness for KSPFoundation.MQTTClientProtocol.subscribe<A where A1: KSPFoundation.MQTTTopicProtocol>(topic: A1) -> () in conformance KSPProvider.CocoaMQTTClient : KSPFoundation.MQTTClientProtocol in KSPProvider <null> (Sports.debug.dylib:arm64+0x6666880)
    #9 closure #1 () -> () in closure #1 () async -> () in KSPProvider.MQTTManager.subscribe<A where A: KSPFoundation.MQTTTopicProtocol>(topic: A) -> () <null> (Sports.debug.dylib:arm64+0x66730cc)
    #10 partial apply forwarder for closure #1 () -> () in closure #1 () async -> () in KSPProvider.MQTTManager.subscribe<A where A: KSPFoundation.MQTTTopicProtocol>(topic: A) -> () <null> (Sports.debug.dylib:arm64+0x6674fc0)
    #11 KSPProvider.SubscriptionCounter.register(topicInString: Swift.String, subscribeAction: () -> ()) -> () <null> (Sports.debug.dylib:arm64+0x66d24f8)
    #12 (8) suspend resume partial function for closure #1 () async -> () in KSPProvider.MQTTManager.subscribe<A where A: KSPFoundation.MQTTTopicProtocol>(topic: A) -> () <null> (Sports.debug.dylib:arm64+0x6672c88)
    #13 swift::runJobInEstablishedExecutorContext(swift::Job*) <null> (libswift_Concurrency.dylib:arm64+0x42c2c)

  Location is heap block of size 16 at 0x00010bd0eb10 allocated by thread T7:
    #0 calloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x53b90)
    #1 _malloc_type_calloc_outlined <null> (libsystem_malloc.dylib:arm64+0xfe68)
    #2 one-time initialization function for logger <null> (Sports.debug.dylib:arm64+0x678aa8c)
    #3 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x7cb1c)
    #4 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x7cbb8)
    #5 CocoaMQTT.CocoaMQTTLogger.logger.unsafeMutableAddressor : CocoaMQTT.CocoaMQTTLogger <null> (Sports.debug.dylib:arm64+0x678a238)
    #6 CocoaMQTT.CocoaMQTT5.logLevel.setter : CocoaMQTT.CocoaMQTTLoggerLevel <null> (Sports.debug.dylib:arm64+0x675cd54)
    #7 KSPProvider.CocoaMQTTClient.(makeMQTTClient in _328B7F2CDB09E6727F76035FE7F7EE01)(for: KSPFoundation.MQTTClientConfiguration) -> CocoaMQTT.CocoaMQTT5 <null> (Sports.debug.dylib:arm64+0x666553c)
    #8 KSPProvider.CocoaMQTTClient.connect() -> () <null> (Sports.debug.dylib:arm64+0x666442c)
    #9 protocol witness for KSPFoundation.MQTTClientProtocol.connect() -> () in conformance KSPProvider.CocoaMQTTClient : KSPFoundation.MQTTClientProtocol in KSPProvider <null> (Sports.debug.dylib:arm64+0x66667c0)
    #10 closure #1 () -> () in closure #1 () async -> () in KSPProvider.MQTTManager.connect() -> () <null> (Sports.debug.dylib:arm64+0x6671b20)
    #11 partial apply forwarder for closure #1 () -> () in closure #1 () async -> () in KSPProvider.MQTTManager.connect() -> () <null> (Sports.debug.dylib:arm64+0x6674d78)
    #12 KSPProvider.MQTTConnection.connect(connectAction: () -> ()) -> () <null> (Sports.debug.dylib:arm64+0x666bd6c)
    #13 (2) suspend resume partial function for closure #1 () async -> () in KSPProvider.MQTTManager.connect() -> () <null> (Sports.debug.dylib:arm64+0x6671948)
    #14 swift::runJobInEstablishedExecutorContext(swift::Job*) <null> (libswift_Concurrency.dylib:arm64+0x42c2c)

  Thread T342 (tid=45915899, running) is a GCD worker thread

  Thread T336 (tid=45909843, running) is a GCD worker thread

  Thread T7 (tid=45821245, finished) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race (/Users/zhitan/Library/Developer/CoreSimulator/Devices/1D0CA366-8AA7-4FB9-B0A0-087FA8AE747A/data/Containers/Bundle/Application/0B274694-E81E-4052-B863-9B39BE9BBED2/Sports.app/Sports.debug.dylib:arm64+0x678b2c8) in CocoaMQTT.CocoaMQTTLogger.minLevel.setter : CocoaMQTT.CocoaMQTTLoggerLevel+0x98
```

## Reason
`CocoaMQTTLogger.logger` is a shared static instance accessed across different threads. logLevel reads and writes logger.minLevel without synchronization. This caused data races when multiple threads accessed or mutated the property simultaneously.

## Solution
We introduced a concurrent DispatchQueue with barrier flags to ensure thread-safe access to the logLevel property:
```
private let loggerQueue = DispatchQueue(label: "CocoaMQTTLogger.queue", attributes: .concurrent)

public var logLevel: CocoaMQTTLoggerLevel {
    get {
        loggerQueue.sync {
            CocoaMQTTLogger.logger.minLevel
        }
    }
    set {
        loggerQueue.async(flags: .barrier) {
            CocoaMQTTLogger.logger.minLevel = newValue
        }
    }
}
```
This approach ensures:
Concurrent reads are allowed, providing better performance in read-heavy scenarios.
Writes are serialized using .barrier, ensuring exclusive access and data consistency.


