### PR TITLE
Bugfix/ksp2 2560 introduce concurrent atomic and fix data race

### DIFF
--- a/CocoaMQTTTests/ConcurrentAtomicTests.swift
+++ b/CocoaMQTTTests/ConcurrentAtomicTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import CocoaMQTT
+
+final class ConcurrentAtomicTests: XCTestCase {
+    @ConcurrentAtomic var value: Int = 1
+
+    func testSetSync() {
+        $value.setSync(10)
+        XCTAssertEqual($value.wrappedValue, 10, "Set value should be reflected")
+    }
+
+        func testMutate() {
+            // Reset the value to a known state
+            $value.setSync(1)
+            XCTAssertEqual(self.value, 1, "Immediately after async mutate, value should still be 1")
+            // Asynchronously multiply the value
+            $value.mutate {
+                // 0.1 seconds delay
+                usleep(100_000)
+                $0 *= 20
+            }
+            XCTAssertEqual(self.value, 20, "Value should still be 20 immediately after async mutate is called")
+        }
+
+        func testMultipleAsyncMutations() {
+            let expectation = XCTestExpectation(description: "All async mutations completed")
+
+            // Reset to zero before starting concurrent increments
+            $value.setSync(0)
+
+            let group = DispatchGroup()
+            let queue = DispatchQueue.global(qos: .userInitiated)
+
+            // Perform 100 asynchronous increments
+            for _ in 0..<100 {
+                group.enter()
+                queue.async {
+                    self.$value.mutate { $0 += 1 }
+                    group.leave()
+                }
+            }
+
+            // Wait for all tasks to finish, then check the result
+            group.notify(queue: .main) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    XCTAssertEqual(self.value, 100, "All async mutate operations should complete successfully")
+                    expectation.fulfill()
+                }
+            }
+
+            wait(for: [expectation], timeout: 1.0)
+        }
+}

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -172,7 +172,8 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// The delegate/closure callback function will be committed asynchronously to it
     public var delegateQueue = DispatchQueue.main
 
-    public var connState = CocoaMQTTConnState.disconnected {
+    @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
+    public var connState {
         didSet {
             __delegate_queue {
                 self.delegate?.mqtt5?(self, didStateChangeTo: self.connState)

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -236,18 +236,13 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     private var autoReconnTimer: CocoaMQTTTimer?
     private var is_internal_disconnected = false
 
-    private let loggerQueue = DispatchQueue(label: "CocoaMQTT5.logLevel", attributes: .concurrent)
     /// Console log level
     public var logLevel: CocoaMQTTLoggerLevel {
         get {
-            loggerQueue.sync {
-                CocoaMQTTLogger.logger.minLevel
-            }
+            return CocoaMQTTLogger.logger.minLevel
         }
         set {
-            loggerQueue.async(flags: .barrier) {
-                CocoaMQTTLogger.logger.minLevel = newValue
-            }
+            CocoaMQTTLogger.logger.minLevel = newValue
         }
     }
 

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -172,8 +172,7 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
     /// The delegate/closure callback function will be committed asynchronously to it
     public var delegateQueue = DispatchQueue.main
 
-    @ConcurrentAtomic(wrappedValue: CocoaMQTTConnState.disconnected, label: "CocoaMQTT5.connState")
-    public var connState: CocoaMQTTConnState {
+    public var connState = CocoaMQTTConnState.disconnected {
         didSet {
             __delegate_queue {
                 self.delegate?.mqtt5?(self, didStateChangeTo: self.connState)

--- a/Source/CocoaMQTT5.swift
+++ b/Source/CocoaMQTT5.swift
@@ -235,7 +235,6 @@ public class CocoaMQTT5: NSObject, CocoaMQTT5Client {
 
     private var autoReconnTimer: CocoaMQTTTimer?
     private var is_internal_disconnected = false
-    
 
     private let loggerQueue = DispatchQueue(label: "CocoaMQTT5.logLevel", attributes: .concurrent)
     /// Console log level

--- a/Source/CocoaMQTTLogger.swift
+++ b/Source/CocoaMQTTLogger.swift
@@ -39,7 +39,8 @@ open class CocoaMQTTLogger: NSObject {
     public override init() { super.init() }
 
     // min level
-    var minLevel: CocoaMQTTLoggerLevel = .warning
+    @ConcurrentAtomic(wrappedValue: .warning, label: "CocoaMQTTLogger.minLevel")
+    var minLevel: CocoaMQTTLoggerLevel
     
     // logs
     open func log(level: CocoaMQTTLoggerLevel, message: String) {

--- a/Source/CocoaMQTTWebSocket.swift
+++ b/Source/CocoaMQTTWebSocket.swift
@@ -142,6 +142,7 @@ public class CocoaMQTTWebSocket: CocoaMQTTSocketProtocol {
         }
     }
     
+    @ConcurrentAtomic(wrappedValue: nil, label: "CocoaMQTTWebSocket.delegate")
     internal var delegate: CocoaMQTTSocketDelegate?
     internal var delegateQueue: DispatchQueue?
     internal var internalQueue = DispatchQueue(label: "CocoaMQTTWebSocket")

--- a/Source/utilities/ConcurrentAtomic.swift
+++ b/Source/utilities/ConcurrentAtomic.swift
@@ -70,16 +70,4 @@ public class ConcurrentAtomic<T> {
             transform(&self._value)
         }
     }
-
-    /// Synchronously mutates the wrapped value using a transform closure.
-    ///
-    /// The mutation is performed with `.barrier` and blocks until completed. Useful when you need
-    /// immediate consistency after the change.
-    ///
-    /// - Parameter transform: A closure that receives `inout` access to the wrapped value.
-    public func mutateSync(_ transform: (inout T) -> Void) {
-        queue.sync(flags: .barrier) {
-            transform(&self._value)
-        }
-    }
 }

--- a/Source/utilities/ConcurrentAtomic.swift
+++ b/Source/utilities/ConcurrentAtomic.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// A thread-safe property wrapper that uses a concurrent dispatch queue for atomic operations.
+///
+/// This wrapper provides both synchronous and asynchronous access to a wrapped value in a
+/// thread-safe manner using `DispatchQueue` with `.concurrent` attributes and `.barrier` writes.
+///
+/// - Important: Although this wrapper provides atomicity for access, it does not make the wrapped
+///   value itself thread-safe if the type is not thread-safe. Avoid wrapping types that manage
+///   internal shared state without their own synchronization.
+///
+/// - Example:
+/// ```swift
+/// @ConcurrentAtomic var counter: Int = 0
+/// counter += 1
+/// print(counter)
+/// ```
+@propertyWrapper
+public class ConcurrentAtomic<T> {
+    private var _value: T
+    private let queue: DispatchQueue
+
+    /// Provides synchronous thread-safe access to the wrapped value.
+    ///
+    /// - Note: Reads use `queue.sync` and can happen concurrently.
+    /// - Warning: Writes are done asynchronously with `.barrier`, so a following read may
+    ///   not reflect the new value immediately.
+    public var wrappedValue: T {
+        get {
+            queue.sync { _value }
+        }
+        set {
+            queue.async(flags: .barrier) {
+                self._value = newValue
+            }
+        }
+    }
+
+    /// Returns the property wrapper instance itself for advanced usage, including mutation and transformation APIs.
+    public var projectedValue: ConcurrentAtomic<T> { self }
+
+    /// Initializes the property wrapper with an initial value and a custom queue label.
+    ///
+    /// - Parameters:
+    ///   - wrappedValue: The initial value to store.
+    ///   - label: A debug label for the underlying `DispatchQueue`. Default is `"ConcurrentAtomic.Queue"`.
+    public init(wrappedValue: T, label: String = "ConcurrentAtomic.Queue") {
+        self._value = wrappedValue
+        self.queue = DispatchQueue(label: label, attributes: .concurrent)
+    }
+
+    /// Synchronously sets a new value in a thread-safe manner.
+    ///
+    /// This uses `.barrier` to ensure the new value is fully written before continuing.
+    ///
+    /// - Parameter newValue: The new value to be written.
+    public func setSync(_ newValue: T) {
+        queue.sync(flags: .barrier) {
+            self._value = newValue
+        }
+    }
+
+    /// Asynchronously mutates the wrapped value using a transform closure.
+    ///
+    /// The mutation is performed with `.barrier`, ensuring it does not overlap with other reads or writes.
+    ///
+    /// - Parameter transform: A closure that receives `inout` access to the wrapped value.
+    public func mutate(_ transform: @escaping (inout T) -> Void) {
+        queue.async(flags: .barrier) {
+            transform(&self._value)
+        }
+    }
+
+    /// Synchronously mutates the wrapped value using a transform closure.
+    ///
+    /// The mutation is performed with `.barrier` and blocks until completed. Useful when you need
+    /// immediate consistency after the change.
+    ///
+    /// - Parameter transform: A closure that receives `inout` access to the wrapped value.
+    public func mutateSync(_ transform: (inout T) -> Void) {
+        queue.sync(flags: .barrier) {
+            transform(&self._value)
+        }
+    }
+}


### PR DESCRIPTION
ThreadSanitizer reported a data race issue when accessing the delegate and delegateQueue properties. The existing implementation assigns these properties asynchronously using a serial queue:

```
internal var internalQueue = DispatchQueue(label: "CocoaMQTTWebSocket")

public func setDelegate(_ theDelegate: CocoaMQTTSocketDelegate?, delegateQueue: DispatchQueue?) {
    internalQueue.async {
        self.delegate = theDelegate
        self.delegateQueue = delegateQueue
    }
}
```
Although a serial queue is used, the asynchronous call (async) does not guarantee timing consistency, which could lead to concurrent reads and writes if other parts of the code access delegate outside this queue.

## Solution
We introduce ConcurrentAtomic object wrapper, in which there is a concurrent DispatchQueue and updated the setter method to use a .barrier flag. This ensures multiple concurrent reads are allowed.
Writes are serialized with a barrier and will not happen concurrently with reads or other writes.

This approach ensures thread-safe reads and writes without blocking non-mutating operations.